### PR TITLE
Fix: Resolve Linting Errors in Middleware

### DIFF
--- a/server/src/middleware/error/error-logger.ts
+++ b/server/src/middleware/error/error-logger.ts
@@ -4,7 +4,7 @@ import { IError } from '../../types/IError';
 export const errorLogger = (
   err: IError,
   req: Request,
-  res: Response,
+  _res: Response,
   next: NextFunction
 ) => {
     console.error('Error:', {

--- a/server/src/middleware/error/error-responder.ts
+++ b/server/src/middleware/error/error-responder.ts
@@ -4,9 +4,9 @@ import { IError } from '../../types/IError';
 
 export const errorResponder = (
   err: IError,
-  req: Request,
+  _req: Request,
   res: Response,
-  next: NextFunction
+  _next: NextFunction
 ) => {
   const statusCode = err.statusCode || StatusCodes.INTERNAL_SERVER_ERROR;
 

--- a/server/src/middleware/not-found.ts
+++ b/server/src/middleware/not-found.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { AppError } from '../errors/AppError';
 
-export const notFound = (req: Request, res: Response, next: NextFunction) => {
+export const notFound = (req: Request, _res: Response, next: NextFunction) => {
   const error = new AppError(
     `Not Found - ${req.originalUrl}`,
     StatusCodes.NOT_FOUND


### PR DESCRIPTION
Fix unused parameter linting errors by prefixing with underscore. Maintains Express middleware signature requirements while satisfying ESLint rules.